### PR TITLE
update runtime to GNOME 45

### DIFF
--- a/io.github.seadve.Breathing.json
+++ b/io.github.seadve.Breathing.json
@@ -1,7 +1,7 @@
 {
   "app-id": "io.github.seadve.Breathing",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "42",
+  "runtime-version": "45",
   "sdk": "org.gnome.Sdk",
   "command": "breathing",
   "finish-args": [


### PR DESCRIPTION
The runtime GNOME 42 is as of now end of life, and should be avoided.